### PR TITLE
Make minor changes to make it more usable as a library

### DIFF
--- a/ip6w/src/ip6words.py
+++ b/ip6w/src/ip6words.py
@@ -36,6 +36,7 @@ def main(argv):
     else:
         raise Exception("Could not determine the type of IP being queried")
     print(res)
+    return res
     
 def parse_args(args):
     cmd_opts = {

--- a/ip6w/src/ip6words.py
+++ b/ip6w/src/ip6words.py
@@ -13,31 +13,29 @@ def conv_to_words(words, ip_to_process, explode_results):
     if explode_results:
         ipwords = ip_handling.to_words.explode_words(ipwords)
 
-    ipstr = ip_handling.to_words.words_arr_to_str(ipwords)
-
-    print(ipstr)
-    return ipstr
+    return ip_handling.to_words.words_arr_to_str(ipwords)
 
 def conv_to_ipv6(words, ip_to_process, explode_results):
     ip = ip_handling.to_ipv6.ip6words_arrayize(ip_to_process)
     ip = ip_handling.to_words.explode_words(ip)
 
     iphex = ip_handling.to_ipv6.words_to_ipv6_arr(ip, words)
-    ipstr = ip_handling.to_ipv6.iphex_arr_to_str(iphex, explode_results)
+    return ip_handling.to_ipv6.iphex_arr_to_str(iphex, explode_results)
 
-    print(ipstr)
-    return ipstr
+def load_words():
+    return dill_words(ip_handling.iutils.get_ipv6_word_possibilities() + 1)
 
 def main(argv):
     ip_to_process, convert_to, explode_results = parse_args(argv[1:])
-    words = dill_words(ip_handling.iutils.get_ipv6_word_possibilities()+1)
-    
+    words = load_words()
+
     if convert_to == "words":
-        return conv_to_words(words, ip_to_process, explode_results)
+        res = conv_to_words(words, ip_to_process, explode_results)
     elif convert_to == "ipv6":
-        return conv_to_ipv6(words, ip_to_process, explode_results)
+        res = conv_to_ipv6(words, ip_to_process, explode_results)
     else:
         raise Exception("Could not determine the type of IP being queried")
+    print(res)
     
 def parse_args(args):
     cmd_opts = {

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.1.5'
+version = '1.1.6'
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()


### PR DESCRIPTION
Just basic stuff, like not having print statements in the conversion functions and having the loading of words in its own function so it is easier to use as a library in other stuff.